### PR TITLE
refactor: improve vite dev server check with manifest presence

### DIFF
--- a/providers/vite_provider.ts
+++ b/providers/vite_provider.ts
@@ -21,15 +21,9 @@ declare module '@adonisjs/core/types' {
 }
 
 export default class ViteProvider {
-  #shouldRunVite: boolean
+  #shouldRunViteDevServer = false
 
-  constructor(protected app: ApplicationService) {
-    /**
-     * We should only run Vite in development and test environments
-     */
-    const env = this.app.getEnvironment()
-    this.#shouldRunVite = (this.app.inDev || this.app.inTest) && (env === 'web' || env === 'test')
-  }
+  constructor(protected app: ApplicationService) {}
 
   /**
    * Registers edge plugin when edge is installed
@@ -76,9 +70,12 @@ export default class ViteProvider {
    * Register Vite bindings
    */
   register() {
-    const config = this.app.config.get<ViteOptions>('vite')
+    const appEnvironment = this.app.getEnvironment()
+    const isWebOrTestEnvironment = appEnvironment === 'web' || appEnvironment === 'test'
 
-    const vite = new Vite(this.#shouldRunVite, config)
+    const vite = new Vite(this.app.config.get<ViteOptions>('vite'))
+    this.#shouldRunViteDevServer = !vite.hasManifestFile && isWebOrTestEnvironment
+
     this.app.container.bind('vite', () => vite)
     this.app.container.singleton(ViteMiddleware, () => new ViteMiddleware(vite))
   }
@@ -90,7 +87,7 @@ export default class ViteProvider {
   async boot() {
     await this.registerEdgePlugin()
 
-    if (!this.#shouldRunVite) return
+    if (!this.#shouldRunViteDevServer) return
 
     const vite = await this.app.container.make('vite')
     await vite.createDevServer()
@@ -100,7 +97,7 @@ export default class ViteProvider {
    * Stop Vite server when running in development or test
    */
   async shutdown() {
-    if (!this.#shouldRunVite) return
+    if (!this.#shouldRunViteDevServer) return
 
     const vite = await this.app.container.make('vite')
     await vite.stopDevServer()

--- a/src/vite.ts
+++ b/src/vite.ts
@@ -8,7 +8,7 @@
  */
 
 import { join } from 'node:path'
-import { readFileSync } from 'node:fs'
+import { existsSync, readFileSync } from 'node:fs'
 import { slash } from '@poppinss/utils'
 import { ModuleRunner } from 'vite/module-runner'
 import type {
@@ -37,13 +37,16 @@ export class Vite {
   #options: ViteOptions
   #devServer?: ViteDevServer
   #createServerPromise?: Promise<ViteDevServer>
+  hasManifestFile: boolean
 
-  constructor(
-    protected isViteRunning: boolean,
-    options: ViteOptions
-  ) {
+  constructor(options: ViteOptions) {
     this.#options = options
     this.#options.assetsUrl = (this.#options.assetsUrl || '/').replace(/\/$/, '')
+    this.hasManifestFile = this.#hasManifestFile()
+  }
+
+  #hasManifestFile() {
+    return existsSync(this.#options.manifestFile)
   }
 
   /**
@@ -149,7 +152,7 @@ export class Vite {
    */
   #generateTag(asset: string, attributes?: Record<string, any>): AdonisViteElement {
     let url = ''
-    if (this.isViteRunning) {
+    if (!this.hasManifestFile) {
       url = `/${asset}`
     } else {
       url = this.#generateAssetUrl(asset)
@@ -365,7 +368,7 @@ export class Vite {
   ): Promise<AdonisViteElement[]> {
     entryPoints = Array.isArray(entryPoints) ? entryPoints : [entryPoints]
 
-    if (this.isViteRunning) {
+    if (!this.hasManifestFile) {
       return this.#generateEntryPointsTagsForDevMode(entryPoints, attributes)
     }
 
@@ -383,7 +386,7 @@ export class Vite {
    * Returns path to a given asset file using the manifest file
    */
   assetPath(asset: string): string {
-    if (this.isViteRunning) {
+    if (!this.hasManifestFile) {
       return `/${asset}`
     }
 
@@ -397,7 +400,7 @@ export class Vite {
    * @throws Will throw an exception when running in dev
    */
   manifest(): Manifest {
-    if (this.isViteRunning) {
+    if (!this.hasManifestFile) {
       throw new Error('Cannot read the manifest file when running in dev mode')
     }
 
@@ -460,9 +463,7 @@ export class Vite {
    * Returns the script needed for the HMR working with React
    */
   getReactHmrScript(attributes?: Record<string, any>): AdonisViteElement | null {
-    if (!this.isViteRunning) {
-      return null
-    }
+    if (this.hasManifestFile) return null
 
     return this.#generateElement({
       tag: 'script',

--- a/tests/backend/edge_plugin.spec.ts
+++ b/tests/backend/edge_plugin.spec.ts
@@ -10,8 +10,7 @@
 import { Edge } from 'edge.js'
 import { test } from '@japa/runner'
 
-import { Vite } from '../../src/vite.js'
-import { createVite } from './helpers.js'
+import { createVite, setupViteWithManifest } from './helpers.js'
 import { defineConfig } from '../../src/define_config.js'
 import { edgePluginVite } from '../../src/plugins/edge.js'
 
@@ -70,7 +69,7 @@ test.group('Edge plugin vite', () => {
 
   test('do not output hmrScript when not in hot mode', async ({ assert }) => {
     const edge = Edge.create()
-    const vite = new Vite(false, defineConfig({}))
+    const vite = await setupViteWithManifest()
     edge.use(edgePluginVite(vite))
 
     const html = await edge.renderRaw(`@viteReactRefresh()`)

--- a/tests/backend/helpers.ts
+++ b/tests/backend/helpers.ts
@@ -9,9 +9,10 @@
 
 import { getActiveTest } from '@japa/runner'
 
-import { Vite } from '../../index.js'
+import { defineConfig, Vite } from '../../index.js'
 import { ViteOptions } from '../../src/types.js'
 import { InlineConfig } from 'vite'
+import { join } from 'node:path'
 
 export const BASE_URL = new URL('./../__app/', import.meta.url)
 
@@ -31,8 +32,7 @@ export async function createVite(config: ViteOptions, viteConfig: InlineConfig =
    */
   await test.context.fs.create('dummy.txt', 'dummy')
 
-  const vite = new Vite(true, config)
-
+  const vite = new Vite(config)
   await vite.createDevServer({
     logLevel: 'silent',
     clearScreen: false,
@@ -41,6 +41,18 @@ export async function createVite(config: ViteOptions, viteConfig: InlineConfig =
   })
 
   test.cleanup(() => vite.stopDevServer())
+
+  return vite
+}
+
+export async function setupViteWithManifest(config?: Partial<ViteOptions>) {
+  const test = getActiveTest()
+  if (!test) throw new Error('Cannot create vite instance outside of a test')
+
+  await test.context.fs.create('public/assets/.vite/manifest.json', '')
+
+  const defaultManifestPath = join(test.context.fs.basePath, 'public/assets/.vite/manifest.json')
+  const vite = new Vite(defineConfig(config || { manifestFile: defaultManifestPath }))
 
   return vite
 }

--- a/tests/backend/middleware.spec.ts
+++ b/tests/backend/middleware.spec.ts
@@ -54,7 +54,7 @@ test.group('Vite Middleware', () => {
       }
     }
 
-    const vite = new FakeVite(false, { buildDirectory: 'foo', manifestFile: 'bar.json' })
+    const vite = new FakeVite({ buildDirectory: 'foo', manifestFile: 'bar.json' })
 
     const server = createServer(async (req, res) => {
       const middleware = new ViteMiddleware(vite)

--- a/tests/backend/provider.spec.ts
+++ b/tests/backend/provider.spec.ts
@@ -13,6 +13,7 @@ import { IgnitorFactory } from '@adonisjs/core/factories'
 
 import { defineConfig } from '../../index.js'
 import ViteMiddleware from '../../src/vite_middleware.js'
+import { join } from 'node:path'
 
 const BASE_URL = new URL('./tmp/', import.meta.url)
 const IMPORTER = (filePath: string) => {
@@ -24,8 +25,6 @@ const IMPORTER = (filePath: string) => {
 
 test.group('Vite Provider', () => {
   test('register vite middleware singleton', async ({ assert }) => {
-    process.env.NODE_ENV = 'development'
-
     const ignitor = new IgnitorFactory()
       .merge({ rcFileContents: { providers: [() => import('../../providers/vite_provider.js')] } })
       .withCoreConfig()
@@ -43,8 +42,6 @@ test.group('Vite Provider', () => {
   })
 
   test('launch dev server in dev mode', async ({ assert }) => {
-    process.env.NODE_ENV = 'development'
-
     const ignitor = new IgnitorFactory()
       .merge({ rcFileContents: { providers: [() => import('../../providers/vite_provider.js')] } })
       .withCoreConfig()
@@ -64,16 +61,21 @@ test.group('Vite Provider', () => {
     await app.terminate()
   })
 
-  test('doesnt launch dev server in prod', async ({ assert }) => {
-    process.env.NODE_ENV = 'production'
-
+  test('doesnt launch dev server if manifest exist', async ({ assert, fs }) => {
     const ignitor = new IgnitorFactory()
       .merge({ rcFileContents: { providers: [() => import('../../providers/vite_provider.js')] } })
       .withCoreConfig()
       .withCoreProviders()
-      .merge({ config: { vite: defineConfig({}) } })
+      .merge({
+        config: {
+          vite: defineConfig({
+            manifestFile: join(fs.basePath, 'public/assets/.vite/manifest.json'),
+          }),
+        },
+      })
       .create(BASE_URL, { importer: IMPORTER })
 
+    await fs.create('public/assets/.vite/manifest.json', '{}')
     const app = ignitor.createApp('web')
     await app.init()
     await app.boot()
@@ -85,8 +87,6 @@ test.group('Vite Provider', () => {
   })
 
   test('run dev server in test', async ({ assert }) => {
-    process.env.NODE_ENV = 'test'
-
     const ignitor = new IgnitorFactory()
       .merge({ rcFileContents: { providers: [() => import('../../providers/vite_provider.js')] } })
       .withCoreConfig()
@@ -124,37 +124,6 @@ test.group('Vite Provider', () => {
   })
 
   test('register edge plugin', async ({ assert }) => {
-    process.env.NODE_ENV = 'development'
-
-    const ignitor = new IgnitorFactory()
-      .merge({
-        rcFileContents: {
-          providers: [
-            () => import('../../providers/vite_provider.js'),
-            () => import('@adonisjs/core/providers/edge_provider'),
-          ],
-        },
-      })
-      .withCoreConfig()
-      .withCoreProviders()
-      .merge({ config: { vite: defineConfig({}) } })
-      .create(BASE_URL, { importer: IMPORTER })
-
-    const app = ignitor.createApp('web')
-    await app.init()
-    await app.boot()
-
-    const edge = await import('edge.js')
-    await edge.default.renderRaw('')
-
-    assert.isDefined(edge.default.tags.vite)
-
-    await app.terminate()
-  })
-
-  test('register edge plugin in production', async ({ assert }) => {
-    process.env.NODE_ENV = 'production'
-
     const ignitor = new IgnitorFactory()
       .merge({
         rcFileContents: {

--- a/tests/backend/vite.spec.ts
+++ b/tests/backend/vite.spec.ts
@@ -11,8 +11,7 @@ import { join } from 'node:path'
 import { test } from '@japa/runner'
 import { fileURLToPath } from 'node:url'
 
-import { Vite } from '../../src/vite.js'
-import { createVite } from './helpers.js'
+import { createVite, setupViteWithManifest } from './helpers.js'
 import { defineConfig } from '../../src/define_config.js'
 
 test.group('Vite | dev', () => {
@@ -205,12 +204,9 @@ test.group('Vite | dev', () => {
 
 test.group('Vite | manifest', () => {
   test('generate entrypoints tags for a file', async ({ assert, fs, cleanup }) => {
-    const vite = new Vite(
-      false,
-      defineConfig({
-        buildDirectory: join(fs.basePath, 'public/assets'),
-      })
-    )
+    const vite = await setupViteWithManifest({
+      buildDirectory: join(fs.basePath, 'public/assets'),
+    })
 
     await vite.createDevServer()
     cleanup(() => vite.stopDevServer())
@@ -236,12 +232,9 @@ test.group('Vite | manifest', () => {
   })
 
   test('generate entrypoints with css imported inside js', async ({ assert, fs }) => {
-    const vite = new Vite(
-      false,
-      defineConfig({
-        buildDirectory: join(fs.basePath, 'public/assets'),
-      })
-    )
+    const vite = await setupViteWithManifest({
+      buildDirectory: join(fs.basePath, 'public/assets'),
+    })
 
     await fs.create(
       'public/assets/.vite/manifest.json',
@@ -274,13 +267,10 @@ test.group('Vite | manifest', () => {
   })
 
   test('prefix assetsUrl', async ({ assert, fs }) => {
-    const vite = new Vite(
-      false,
-      defineConfig({
-        buildDirectory: join(fs.basePath, 'public/assets'),
-        assetsUrl: 'https://cdn.url.com',
-      })
-    )
+    const vite = await setupViteWithManifest({
+      buildDirectory: join(fs.basePath, 'public/assets'),
+      assetsUrl: 'https://cdn.url.com',
+    })
 
     await fs.create(
       'public/assets/.vite/manifest.json',
@@ -303,12 +293,9 @@ test.group('Vite | manifest', () => {
   })
 
   test('access manifest file', async ({ fs, assert }) => {
-    const vite = new Vite(
-      false,
-      defineConfig({
-        buildDirectory: join(fs.basePath, 'public/assets'),
-      })
-    )
+    const vite = await setupViteWithManifest({
+      buildDirectory: join(fs.basePath, 'public/assets'),
+    })
 
     await fs.create(
       'public/assets/.vite/manifest.json',
@@ -319,12 +306,9 @@ test.group('Vite | manifest', () => {
   })
 
   test('get asset path', async ({ fs, assert }) => {
-    const vite = new Vite(
-      false,
-      defineConfig({
-        buildDirectory: join(fs.basePath, 'public/assets'),
-      })
-    )
+    const vite = await setupViteWithManifest({
+      buildDirectory: join(fs.basePath, 'public/assets'),
+    })
 
     await fs.create(
       'public/assets/.vite/manifest.json',
@@ -335,12 +319,9 @@ test.group('Vite | manifest', () => {
   })
 
   test('throw error when manifest does not have the chunk', async ({ fs }) => {
-    const vite = new Vite(
-      false,
-      defineConfig({
-        buildDirectory: join(fs.basePath, 'public/assets'),
-      })
-    )
+    const vite = await setupViteWithManifest({
+      buildDirectory: join(fs.basePath, 'public/assets'),
+    })
 
     await fs.create(
       'public/assets/.vite/manifest.json',
@@ -351,13 +332,10 @@ test.group('Vite | manifest', () => {
   }).throws('Cannot find "app.css" chunk in the manifest file')
 
   test('prefix custom assetsUrl to the assetPath', async ({ fs, assert }) => {
-    const vite = new Vite(
-      false,
-      defineConfig({
-        buildDirectory: join(fs.basePath, 'public/assets'),
-        assetsUrl: 'https://cdn.url.com',
-      })
-    )
+    const vite = await setupViteWithManifest({
+      buildDirectory: join(fs.basePath, 'public/assets'),
+      assetsUrl: 'https://cdn.url.com',
+    })
 
     await fs.create(
       'public/assets/.vite/manifest.json',
@@ -368,13 +346,10 @@ test.group('Vite | manifest', () => {
   })
 
   test('return null for viteHMRScript when not in hot mode', async ({ fs, assert }) => {
-    const vite = new Vite(
-      false,
-      defineConfig({
-        buildDirectory: join(fs.basePath, 'public/assets'),
-        assetsUrl: 'https://cdn.url.com',
-      })
-    )
+    const vite = await setupViteWithManifest({
+      buildDirectory: join(fs.basePath, 'public/assets'),
+      assetsUrl: 'https://cdn.url.com',
+    })
 
     await fs.create(
       'public/assets/.vite/manifest.json',
@@ -385,18 +360,15 @@ test.group('Vite | manifest', () => {
   })
 
   test('add custom attributes to the entrypoints script tags', async ({ assert, fs }) => {
-    const vite = new Vite(
-      false,
-      defineConfig({
-        buildDirectory: join(fs.basePath, 'public/assets'),
-        assetsUrl: 'https://cdn.url.com',
-        scriptAttributes: () => {
-          return {
-            'data-test': 'test',
-          }
-        },
-      })
-    )
+    const vite = await setupViteWithManifest({
+      buildDirectory: join(fs.basePath, 'public/assets'),
+      assetsUrl: 'https://cdn.url.com',
+      scriptAttributes: () => {
+        return {
+          'data-test': 'test',
+        }
+      },
+    })
 
     await fs.create(
       'public/assets/.vite/manifest.json',
@@ -423,16 +395,13 @@ test.group('Vite | manifest', () => {
   })
 
   test('add custom attributes to the entrypoints link tags', async ({ assert, fs }) => {
-    const vite = new Vite(
-      false,
-      defineConfig({
-        buildDirectory: join(fs.basePath, 'public/assets'),
-        assetsUrl: 'https://cdn.url.com',
-        styleAttributes: {
-          'data-test': 'test',
-        },
-      })
-    )
+    const vite = await setupViteWithManifest({
+      buildDirectory: join(fs.basePath, 'public/assets'),
+      assetsUrl: 'https://cdn.url.com',
+      styleAttributes: {
+        'data-test': 'test',
+      },
+    })
 
     await fs.create(
       'public/assets/.vite/manifest.json',
@@ -458,13 +427,10 @@ test.group('Vite | manifest', () => {
   })
 
   test('add integrity attribute to entrypoint tags', async ({ assert, fs }) => {
-    const vite = new Vite(
-      false,
-      defineConfig({
-        buildDirectory: join(fs.basePath, 'public/assets'),
-        assetsUrl: 'https://cdn.url.com',
-      })
-    )
+    const vite = await setupViteWithManifest({
+      buildDirectory: join(fs.basePath, 'public/assets'),
+      assetsUrl: 'https://cdn.url.com',
+    })
 
     await fs.create(
       'public/assets/.vite/manifest.json',
@@ -508,24 +474,21 @@ test.group('Vite | manifest', () => {
   })
 
   test('return path to assets directory', async ({ assert, fs }) => {
-    const vite = new Vite(
-      false,
-      defineConfig({
-        buildDirectory: join(fs.basePath, 'public/assets'),
-      })
-    )
+    const vite = await setupViteWithManifest({
+      buildDirectory: join(fs.basePath, 'public/assets'),
+    })
 
     assert.equal(vite.assetsUrl(), '/assets')
   })
 })
 
 test.group('Preloading', () => {
-  const config = defineConfig({
+  const config = {
     manifestFile: fileURLToPath(new URL('fixtures/adonis_packages_manifest.json', import.meta.url)),
-  })
+  }
 
   test('Preload root entrypoints', async ({ assert }) => {
-    const vite = new Vite(false, config)
+    const vite = await setupViteWithManifest(config)
     const entrypoints = await vite.generateEntryPointsTags('resources/pages/home/main.vue')
 
     const result = entrypoints.map((tag) => tag.toString())
@@ -534,7 +497,7 @@ test.group('Preloading', () => {
   })
 
   test('Preload files imported from entrypoints', async ({ assert }) => {
-    const vite = new Vite(false, config)
+    const vite = await setupViteWithManifest(config)
     const entrypoints = await vite.generateEntryPointsTags('resources/pages/home/main.vue')
 
     const result = entrypoints.map((tag) => tag.toString())
@@ -551,7 +514,7 @@ test.group('Preloading', () => {
   })
 
   test('Preload entrypoints css files', async ({ assert }) => {
-    const vite = new Vite(false, config)
+    const vite = await setupViteWithManifest(config)
     const entrypoints = await vite.generateEntryPointsTags('resources/pages/home/main.vue')
 
     const result = entrypoints.map((tag) => tag.toString())
@@ -562,7 +525,7 @@ test.group('Preloading', () => {
   })
 
   test('Preload css files of imported files of entrypoint', async ({ assert }) => {
-    const vite = new Vite(false, config)
+    const vite = await setupViteWithManifest(config)
     const entrypoints = await vite.generateEntryPointsTags('resources/pages/home/main.vue')
 
     const result = entrypoints.map((tag) => tag.toString())
@@ -577,7 +540,7 @@ test.group('Preloading', () => {
   })
 
   test('css preload should be ordered before js preload', async ({ assert }) => {
-    const vite = new Vite(false, config)
+    const vite = await setupViteWithManifest(config)
     const entrypoints = await vite.generateEntryPointsTags('resources/pages/home/main.vue')
 
     const result = entrypoints.map((tag) => tag.toString())
@@ -589,7 +552,7 @@ test.group('Preloading', () => {
   })
 
   test('preloads should use assetsUrl when defined', async ({ assert }) => {
-    const vite = new Vite(false, defineConfig({ ...config, assetsUrl: 'https://cdn.url.com' }))
+    const vite = await setupViteWithManifest({ ...config, assetsUrl: 'https://cdn.url.com' })
     const entrypoints = await vite.generateEntryPointsTags('resources/pages/home/main.vue')
 
     const result = entrypoints.map((tag) => tag.toString())

--- a/tests/configure.spec.ts
+++ b/tests/configure.spec.ts
@@ -86,7 +86,7 @@ test.group('Configure', (group) => {
     await command.exec()
 
     await assert.fileExists('node_modules/vite/package.json')
-  })
+  }).skip(!!process.env.CI, 'Skipping package installation in CI environment')
 
   test('do not prompt when --no-install flag is used', async ({ assert, fs }) => {
     const ignitor = new IgnitorFactory()


### PR DESCRIPTION
Instead of checking if `NODE_ENV=production` to start the Vite dev server, which was quite error-prone, we now check if a manifest is present. If it is we don’t start the dev server, and vice versa
