### PR TITLE
ignore storage and tmp dir in vite server watch config

### DIFF
--- a/stubs/vite.config.stub
+++ b/stubs/vite.config.stub
@@ -19,4 +19,9 @@ export default defineConfig({
       reload: ['resources/views/**/*.edge'],
     }),
   ],
+  server: {
+    watch: {
+      ignored: ['**/storage/**', '**/tmp/**'],
+    },
+  },
 })


### PR DESCRIPTION
<!---
Please carefully read the contribution docs before creating a pull request
 👉 https://github.com/adonisjs/.github/blob/main/docs/CONTRIBUTING.md
-->

### 🔗 Linked issue

- https://github.com/vitejs/vite/issues/21384
- https://github.com/adonisjs/core/issues/5027

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

In an Adonisjs project, `storage` and `tmp` directory don't contain front-end assets. Vite server should not watch them. This can improve Vite performance and avoid unnecessary page refreshing. It can also avoid Vite crashing due to too many file watchers created. (https://github.com/vitejs/vite/issues/21384)

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
