### PR TITLE
build: replace tsup with tsdown

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "precompile": "npm run lint && npm run clean",
     "clean": "del-cli build",
     "copy:templates": "copyfiles --up 1 \"stubs/**/*.stub\" build",
-    "compile": "tsup-node && tsc --emitDeclarationOnly --declaration",
+    "compile": "tsdown && tsc --emitDeclarationOnly --declaration",
     "build": "npm run compile",
     "postbuild": "npm run copy:templates",
     "prebenchmark": "npm run build",
@@ -68,7 +68,7 @@
     "prettier": "^3.8.1",
     "release-it": "^19.2.4",
     "supertest": "^7.2.2",
-    "tsup": "^8.5.1",
+    "tsdown": "^0.21.2",
     "typedoc": "^0.28.17",
     "typescript": "~5.9.3",
     "vite": "^7.3.1"
@@ -140,7 +140,7 @@
       }
     }
   },
-  "tsup": {
+  "tsdown": {
     "entry": [
       "./src/hooks/build_hook.ts",
       "./providers/vite_provider.ts",
@@ -156,7 +156,8 @@
     "format": "esm",
     "dts": false,
     "sourcemap": false,
-    "target": "esnext"
+    "target": "esnext",
+    "fixedExtension": false
   },
   "c8": {
     "reporter": [


### PR DESCRIPTION
<!---
Please carefully read the contribution docs before creating a pull request
 👉 https://github.com/adonisjs/.github/blob/main/docs/CONTRIBUTING.md
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [X] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

This PR replaces ``tsup`` with [tsdown](https://tsdown.dev/). There are some reasons : 
- ``tsup`` is no longer actively maintained
- ``tsdown`` is faster than tsup
- ``tsdown`` runs on rolldown. So, it's a better alignment with the new Vite 8 ecosystem

There are no significant changes to the configuration, except for the ``fixedExtension`` option, which has been set to ``false`` because tsdown generated ``.mjs`` instead of ``.js`` files.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
