### PR TITLE
feat: add support for vite 8

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "tsup": "^8.5.1",
     "typedoc": "^0.28.17",
     "typescript": "~5.9.3",
-    "vite": "^7.3.1"
+    "vite": "^8.0.0"
   },
   "dependencies": {
     "@poppinss/utils": "^7.0.0",
@@ -83,7 +83,7 @@
     "@adonisjs/core": "^7.0.0-next.3 || ^7.0.0",
     "@adonisjs/shield": "^9.0.0-next.0 || ^9.0.0",
     "edge.js": "^6.0.1",
-    "vite": "^7.0.0"
+    "vite": "^8.0.0"
   },
   "peerDependenciesMeta": {
     "edge.js": {

--- a/src/client/config.ts
+++ b/src/client/config.ts
@@ -70,7 +70,7 @@ export function configHook(
       outDir: userConfig.build?.outDir ?? options.buildDirectory,
       assetsInlineLimit: userConfig.build?.assetsInlineLimit ?? 0,
 
-      rollupOptions: {
+      rolldownOptions: {
         input: options.entrypoints.map((entrypoint) => join(userConfig.root || '', entrypoint)),
       },
     },

--- a/tests/backend/vite.spec.ts
+++ b/tests/backend/vite.spec.ts
@@ -570,7 +570,7 @@ test.group('Preloading', () => {
 test.group('Vite | collect css', () => {
   test('collect and preload css files of entrypoint', async ({ assert, fs }) => {
     const vite = await createVite(defineConfig({}), {
-      build: { rollupOptions: { input: 'foo.ts' } },
+      build: { rolldownOptions: { input: 'foo.ts' } },
     })
 
     await fs.create('foo.ts', `import './style.css'`)
@@ -590,7 +590,7 @@ test.group('Vite | collect css', () => {
 
   test('collect recursively css files of entrypoint', async ({ assert, fs }) => {
     const vite = await createVite(defineConfig({}), {
-      build: { rollupOptions: { input: 'foo.ts' } },
+      build: { rolldownOptions: { input: 'foo.ts' } },
     })
 
     await fs.create(
@@ -623,7 +623,7 @@ test.group('Vite | collect css', () => {
 
   test('collect css rendered page', async ({ assert, fs }) => {
     const vite = await createVite(defineConfig({}), {
-      build: { rollupOptions: { input: 'foo.ts' } },
+      build: { rolldownOptions: { input: 'foo.ts' } },
     })
 
     await fs.create(


### PR DESCRIPTION
<!---
Please carefully read the contribution docs before creating a pull request
 👉 https://github.com/adonisjs/.github/blob/main/docs/CONTRIBUTING.md
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [X] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

Added support for vite 8, which greatly increases build speed.

This PR does not include any significant changes. Most of the Vite API used by the plugin appears to have been preserved.

Only two changes:
* **Vite 8.0.0** has been added as a dependency and peer dependency
* ``rollupOptions`` -> ``rolldownOptions``: both are still supported. The change is simply to align with the reality of Vite 8, which now runs under rolldown.

**Just a quick note:** ``vite-plugin-restart`` hasn't been updated yet, so there's a warning about a peer dependency conflict. The plugin still works, though.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
