### PR TITLE
ViteMiddelware: Don't cache vite dev server

### DIFF
--- a/src/vite_middleware.ts
+++ b/src/vite_middleware.ts
@@ -7,7 +7,6 @@
  * file that was distributed with this source code.
  */
 
-import type { ViteDevServer } from 'vite'
 import type { NextFn } from '@adonisjs/core/types/http'
 import type { HttpContext } from '@adonisjs/core/http'
 
@@ -24,8 +23,6 @@ import type { Vite } from './vite.ts'
  * AdonisJS server.
  */
 export default class ViteMiddleware {
-  #devServer: ViteDevServer
-
   /**
    * Creates a new ViteMiddleware instance
    *
@@ -34,9 +31,7 @@ export default class ViteMiddleware {
    * @example
    * const middleware = new ViteMiddleware(viteInstance)
    */
-  constructor(protected vite: Vite) {
-    this.#devServer = this.vite.getDevServer()!
-  }
+  constructor(protected vite: Vite) {}
 
   /**
    * Handles HTTP requests by proxying them to the Vite dev server when appropriate
@@ -49,7 +44,9 @@ export default class ViteMiddleware {
    * await middleware.handle(ctx, next)
    */
   async handle({ request, response }: HttpContext, next: NextFn) {
-    if (!this.#devServer) {
+    const devServer = this.vite.getDevServer()
+
+    if (!devServer) {
       return next()
     }
 
@@ -75,7 +72,7 @@ export default class ViteMiddleware {
        */
       response.relayHeaders()
 
-      this.#devServer.middlewares.handle(request.request, response.response, async () => {
+      devServer.middlewares.handle(request.request, response.response, async () => {
         /**
          * This callback is invoked when Vite does not handle the request. In that
          * case, we will call next and resolve this promise. Also we remove the

--- a/tests/backend/middleware.spec.ts
+++ b/tests/backend/middleware.spec.ts
@@ -91,6 +91,46 @@ test.group('Vite Middleware', () => {
     await supertest(server).get('/resources/js/app.ts')
   })
 
+  test('call getDevServer for each request rather than cache it', async ({ assert, fs }) => {
+    await fs.create('resources/js/app.ts', 'console.log("Hello world")')
+
+    const vite = await createVite(
+      { buildDirectory: 'foo', manifestFile: 'bar.json' },
+      {
+        plugins: [adonisjs({ entrypoints: ['./resources/js/app.ts'] })],
+      }
+    )
+
+    const originalGetDevServer = vite.getDevServer.bind(vite)
+    vite.getDevServer = () => undefined
+
+    const middleware = new ViteMiddleware(vite)
+
+    const server = createServer(async (req, res) => {
+      const request = new RequestFactory().merge({ req, res }).create()
+      const response = new ResponseFactory().merge({ req, res }).create()
+      const ctx = new HttpContextFactory().merge({ request, response }).create()
+
+      await middleware.handle(ctx, () => {
+        ctx.response.status(200).send('vite server not ready, handled by next middleware')
+      })
+
+      if (!ctx.response.finished) {
+        ctx.response.finish()
+      }
+    })
+
+    // Simulate vite server not yet ready
+    const firstRes = await supertest(server).get('/resources/js/app.ts')
+    assert.equal(firstRes.text, 'vite server not ready, handled by next middleware')
+
+    // Simulate vite server now ready
+    vite.getDevServer = originalGetDevServer
+
+    const secondRes = await supertest(server).get('/resources/js/app.ts')
+    assert.include(secondRes.text, 'Hello world')
+  })
+
   test('if vite dev server is not available, call next middleware', async ({ assert }) => {
     class FakeVite extends Vite {
       getDevServer() {


### PR DESCRIPTION
### 🔗 Linked issue

https://github.com/adonisjs/vite/issues/32

### ❓ Type of change

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

It changes the Vite Middleware so that it no longer caches the result of getDevServer upon it's creation.

In the event that the first request to the development server would happen before the vite dev server was ready, the cached value would be "undefined".

This situation could easily happen for automated tests or just when navigating too quickly to the dev server in a browser.

This would cause every subsequent request, meant to be handled by the vite dev server, to fail. E.g. all JS and CSS would fail to load.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.*

\* There was nothing to update
