### PR TITLE
refactor!: use consistent camelCase for `entryPoints` and `serverEntryPoints` plugin options

### DIFF
--- a/src/client/config.ts
+++ b/src/client/config.ts
@@ -77,13 +77,13 @@ export function configHook(
         input:
           userConfig.build?.rolldownOptions?.input ??
           userConfig.build?.rollupOptions?.input ??
-          options.entrypoints,
+          options.entryPoints,
       },
     },
   }
 
   /**
-   * When server-side entrypoints are declared, configure the SSR build
+   * When server-side entry points are declared, configure the SSR build
    * environment so it mirrors the client setup: raw array input, manifest
    * emitted alongside the output. `loadServerModule` reads that manifest
    * at runtime to resolve a source path to the bundled file.
@@ -92,7 +92,7 @@ export function configHook(
    * other plugins contributing to `environments.ssr` cooperate rather
    * than collide.
    */
-  if (options.serverEntrypoints.length > 0) {
+  if (options.serverEntryPoints.length > 0) {
     const userSsrBuild = userConfig.environments?.ssr?.build
     config.environments = {
       ssr: {
@@ -106,7 +106,7 @@ export function configHook(
             input:
               userSsrBuild?.rolldownOptions?.input ??
               (userSsrBuild as any)?.rollupOptions?.input ??
-              options.serverEntrypoints,
+              options.serverEntryPoints,
           },
         },
       },

--- a/src/client/main.ts
+++ b/src/client/main.ts
@@ -29,7 +29,7 @@ export default function adonisjs(options: PluginOptions): PluginOption[] {
       assetsUrl: '/assets',
       buildDirectory: 'public/assets',
       reload: ['./resources/views/**/*.edge'],
-      serverEntrypoints: [] as string[],
+      serverEntryPoints: [] as string[],
     },
     options
   )

--- a/src/client/types.ts
+++ b/src/client/types.ts
@@ -24,9 +24,9 @@ export interface PluginOptions {
   reload?: string[]
 
   /**
-   * Paths to the entrypoints files
+   * Paths to the entry points files
    */
-  entrypoints: string[]
+  entryPoints: string[]
 
   /**
    * Public directory where the assets will be compiled.
@@ -36,18 +36,18 @@ export interface PluginOptions {
   buildDirectory?: string
 
   /**
-   * Server-side entrypoints bundled into the SSR build output. Each
+   * Server-side entry points bundled into the SSR build output. Each
    * entry is emitted as a single bundle (no hash, no shared chunks)
    * under `<buildDirectory>/server/<name>.js` and becomes loadable
    * through `vite.loadServerModule()` at runtime.
    *
    * Paths are relative to the project root.
    */
-  serverEntrypoints?: string[]
+  serverEntryPoints?: string[]
 
   /**
    * Additional files to include in the build that are not imported by the
-   * entrypoints.
+   * entry points.
    *
    * - When passed as a `string[]`, every entry is treated as a chunk: glob
    *   patterns are expanded and each matching file is emitted via Vite's

--- a/src/hooks/build_hook.ts
+++ b/src/hooks/build_hook.ts
@@ -33,7 +33,7 @@ export default hooks.buildStarting(async (parent) => {
    * Force multi-environment builder mode (`useLegacyBuilder = false`).
    * Vite's default builder builds every declared environment when no
    * plugin contributes a custom `buildApp`, which is what we want for
-   * apps that declare both client `entrypoints` and `serverEntrypoints`.
+   * apps that declare both client `entryPoints` and `serverEntryPoints`.
    */
   const builder = await createBuilder({}, false)
   await builder.buildApp()

--- a/src/plugins/edge.ts
+++ b/src/plugins/edge.ts
@@ -116,11 +116,11 @@ export const edgePluginVite: (vite: Vite) => PluginFn<undefined> = (vite) => {
           parser
         )
 
-        const entrypoints = parser.utils.stringify(parsed)
+        const entryPoints = parser.utils.stringify(parsed)
         const methodCall =
           parsed.type === 'SequenceExpression'
-            ? `generateEntryPointsTags${entrypoints}`
-            : `generateEntryPointsTags(${entrypoints})`
+            ? `generateEntryPointsTags${entryPoints}`
+            : `generateEntryPointsTags(${entryPoints})`
 
         buffer.outputExpression(
           `(await state.vite.${methodCall}).join('\\n')`,

--- a/src/server_modules/bundled_module_resolver.ts
+++ b/src/server_modules/bundled_module_resolver.ts
@@ -15,8 +15,8 @@ import type { Manifest } from 'vite'
 /**
  * Resolves and imports server-side modules from the production SSR build.
  *
- * In production there is no Vite dev server — entrypoints declared as
- * `serverEntrypoints` are pre-built into `<buildDirectory>/server` and
+ * In production there is no Vite dev server — entry points declared as
+ * `serverEntryPoints` are pre-built into `<buildDirectory>/server` and
  * recorded in `<buildDirectory>/server/.vite/manifest.json`. The
  * resolver reads that manifest to map an entry source path to the
  * emitted bundle file, then imports it through Node's native `import()`.
@@ -54,7 +54,7 @@ export class BundledModuleResolver {
         throw new Error(
           `Cannot loadServerModule("${entry}"): no chunk for this entry in ` +
             `the SSR manifest. Make sure the entry is declared in ` +
-            `serverEntrypoints and the application has been rebuilt.`
+            `serverEntryPoints and the application has been rebuilt.`
         )
       }
 

--- a/src/server_modules/server_module_loader.ts
+++ b/src/server_modules/server_module_loader.ts
@@ -27,8 +27,8 @@ import type { LoadServerModuleOptions } from '../types.ts'
  *   imports the pre-built bundle from disk.
  *
  * Entry strings are passed through verbatim to mirror how client
- * `entrypoints` are handled — the caller is responsible for using the
- * exact string declared in `serverEntrypoints`.
+ * `entryPoints` are handled — the caller is responsible for using the
+ * exact string declared in `serverEntryPoints`.
  */
 export class ServerModuleLoader {
   #getDevServer: () => ViteDevServer | undefined

--- a/src/vite.ts
+++ b/src/vite.ts
@@ -251,7 +251,7 @@ export class Vite {
     /**
      * If the client module graph is empty, that means we didn't execute the
      * entrypoint yet : we just started the AdonisJS dev server. So let's
-     * execute the entrypoints to populate the client module graph.
+     * execute the entry points to populate the client module graph.
      *
      * Use the per-environment client graph instead of the backward-compat
      * `server.moduleGraph` union (client + ssr). Otherwise an SSR runner
@@ -266,7 +266,7 @@ export class Vite {
     }
 
     /**
-     * We need to collect the CSS files imported by the entrypoints
+     * We need to collect the CSS files imported by the entry points
      * Otherwise, we gonna have a FOUC each time we full reload the page
      */
     const preloadUrls = new Set<string>()
@@ -339,7 +339,7 @@ export class Vite {
   }
 
   /**
-   * Generate style and script tags for the given entrypoints
+   * Generate style and script tags for the given entry points
    * using the manifest file
    */
   #generateEntryPointsTagsWithManifest(

--- a/stubs/vite.config.stub
+++ b/stubs/vite.config.stub
@@ -8,10 +8,10 @@ export default defineConfig({
   plugins: [
     adonisjs({
       /**
-       * Entrypoints of your application. Each entrypoint will
+       * Entry points of your application. Each entrypoint will
        * result in a separate bundle.
        */
-      entrypoints: ['resources/js/app.js'],
+      entryPoints: ['resources/js/app.js'],
 
       /**
        * Paths to watch and reload the browser on file change

--- a/tests/backend/dev_server.spec.ts
+++ b/tests/backend/dev_server.spec.ts
@@ -104,7 +104,7 @@ test.group('Vite dev server', () => {
     await fs.create('resources/js/app.ts', 'console.log("ok")')
 
     const vite = await createVite(defineConfig({}), {
-      plugins: [adonisjs({ entrypoints: ['./resources/js/app.ts'] })],
+      plugins: [adonisjs({ entryPoints: ['./resources/js/app.ts'] })],
     })
 
     const server = vite.getDevServer()!

--- a/tests/backend/middleware.spec.ts
+++ b/tests/backend/middleware.spec.ts
@@ -25,7 +25,7 @@ test.group('Vite Middleware', () => {
     const vite = await createVite(
       { buildDirectory: 'foo', manifestFile: 'bar.json' },
       {
-        plugins: [adonisjs({ entrypoints: ['./resources/js/app.ts'] })],
+        plugins: [adonisjs({ entryPoints: ['./resources/js/app.ts'] })],
       }
     )
 
@@ -123,7 +123,7 @@ test.group('Vite Middleware', () => {
 
     const vite = await createVite(
       { buildDirectory: 'foo', manifestFile: 'bar.json' },
-      { plugins: [adonisjs({ entrypoints: ['./resources/js/app.ts'] })] }
+      { plugins: [adonisjs({ entryPoints: ['./resources/js/app.ts'] })] }
     )
 
     const server = createServer(async (req, res) => {
@@ -147,7 +147,7 @@ test.group('Vite Middleware', () => {
 
     const vite = await createVite(
       { buildDirectory: 'foo', manifestFile: 'bar.json' },
-      { plugins: [adonisjs({ entrypoints: ['./resources/js/app.ts'] })] }
+      { plugins: [adonisjs({ entryPoints: ['./resources/js/app.ts'] })] }
     )
 
     const server = createServer(async (req, res) => {
@@ -173,7 +173,7 @@ test.group('Vite Middleware', () => {
 
     const vite = await createVite(
       { buildDirectory: 'foo', manifestFile: 'bar.json' },
-      { plugins: [adonisjs({ entrypoints: ['./resources/css/app.css'] })] }
+      { plugins: [adonisjs({ entryPoints: ['./resources/css/app.css'] })] }
     )
 
     const server = createServer(async (req, res) => {

--- a/tests/backend/server_modules.spec.ts
+++ b/tests/backend/server_modules.spec.ts
@@ -122,15 +122,15 @@ test.group('Vite | loadServerModule (prod)', () => {
   })
 })
 
-test.group('Vite | configHook serverEntrypoints', () => {
-  test('does not configure ssr environment when serverEntrypoints is empty', ({ assert }) => {
+test.group('Vite | configHook serverEntryPoints', () => {
+  test('does not configure ssr environment when serverEntryPoints is empty', ({ assert }) => {
     const result = configHook(
       {
         assetsUrl: '/assets',
         buildDirectory: 'public/assets',
         reload: [],
-        entrypoints: ['app.ts'],
-        serverEntrypoints: [],
+        entryPoints: ['app.ts'],
+        serverEntryPoints: [],
       },
       { root: '/project' },
       { command: 'build' } as any
@@ -139,14 +139,14 @@ test.group('Vite | configHook serverEntrypoints', () => {
     assert.notProperty(result, 'environments')
   })
 
-  test('configures ssr environment when serverEntrypoints is non-empty', ({ assert }) => {
+  test('configures ssr environment when serverEntryPoints is non-empty', ({ assert }) => {
     const result = configHook(
       {
         assetsUrl: '/assets',
         buildDirectory: 'public/assets',
         reload: [],
-        entrypoints: ['app.ts'],
-        serverEntrypoints: ['inertia/ssr.ts'],
+        entryPoints: ['app.ts'],
+        serverEntryPoints: ['inertia/ssr.ts'],
       },
       { root: '/project' },
       { command: 'build' } as any
@@ -170,8 +170,8 @@ test.group('Vite | configHook serverEntrypoints', () => {
         assetsUrl: '/assets',
         buildDirectory: 'public/assets',
         reload: [],
-        entrypoints: ['app.ts'],
-        serverEntrypoints: ['inertia/ssr.ts'],
+        entryPoints: ['app.ts'],
+        serverEntryPoints: ['inertia/ssr.ts'],
       },
       {
         root: '/project',

--- a/tests/backend/vite.spec.ts
+++ b/tests/backend/vite.spec.ts
@@ -15,7 +15,7 @@ import { createVite, setupViteWithManifest } from './helpers.ts'
 import { defineConfig } from '../../src/define_config.ts'
 
 test.group('Vite | dev', () => {
-  test('generate entrypoints tags for a file', async ({ assert, fs }) => {
+  test('generate entry points tags for a file', async ({ assert, fs }) => {
     const vite = await createVite(
       defineConfig({ buildDirectory: join(fs.basePath, 'public/assets') })
     )
@@ -126,7 +126,7 @@ test.group('Vite | dev', () => {
     })
   })
 
-  test('add custom attributes to the entrypoints script tags', async ({ assert, fs }) => {
+  test('add custom attributes to the entry points script tags', async ({ assert, fs }) => {
     const vite = await createVite(
       defineConfig({
         buildDirectory: join(fs.basePath, 'public/assets'),
@@ -164,7 +164,7 @@ test.group('Vite | dev', () => {
     )
   })
 
-  test('add custom attributes to the entrypoints style tags', async ({ assert, fs }) => {
+  test('add custom attributes to the entry points style tags', async ({ assert, fs }) => {
     const vite = await createVite(
       defineConfig({
         buildDirectory: join(fs.basePath, 'public/assets'),
@@ -203,7 +203,7 @@ test.group('Vite | dev', () => {
 })
 
 test.group('Vite | manifest', () => {
-  test('generate entrypoints tags for a file', async ({ assert, fs }) => {
+  test('generate entry points tags for a file', async ({ assert, fs }) => {
     const vite = await setupViteWithManifest({
       buildDirectory: join(fs.basePath, 'public/assets'),
     })
@@ -228,7 +228,7 @@ test.group('Vite | manifest', () => {
     )
   })
 
-  test('generate entrypoints with css imported inside js', async ({ assert, fs }) => {
+  test('generate entry points with css imported inside js', async ({ assert, fs }) => {
     const vite = await setupViteWithManifest({
       buildDirectory: join(fs.basePath, 'public/assets'),
     })
@@ -356,7 +356,7 @@ test.group('Vite | manifest', () => {
     assert.isNull(vite.getReactHmrScript())
   })
 
-  test('add custom attributes to the entrypoints script tags', async ({ assert, fs }) => {
+  test('add custom attributes to the entry points script tags', async ({ assert, fs }) => {
     const vite = await setupViteWithManifest({
       buildDirectory: join(fs.basePath, 'public/assets'),
       assetsUrl: 'https://cdn.url.com',
@@ -391,7 +391,7 @@ test.group('Vite | manifest', () => {
     )
   })
 
-  test('add custom attributes to the entrypoints link tags', async ({ assert, fs }) => {
+  test('add custom attributes to the entry points link tags', async ({ assert, fs }) => {
     const vite = await setupViteWithManifest({
       buildDirectory: join(fs.basePath, 'public/assets'),
       assetsUrl: 'https://cdn.url.com',
@@ -484,20 +484,20 @@ test.group('Preloading', () => {
     manifestFile: fileURLToPath(new URL('fixtures/adonis_packages_manifest.json', import.meta.url)),
   }
 
-  test('Preload root entrypoints', async ({ assert }) => {
+  test('Preload root entry points', async ({ assert }) => {
     const vite = await setupViteWithManifest(config)
-    const entrypoints = await vite.generateEntryPointsTags('resources/pages/home/main.vue')
+    const entryPoints = await vite.generateEntryPointsTags('resources/pages/home/main.vue')
 
-    const result = entrypoints.map((tag) => tag.toString())
+    const result = entryPoints.map((tag) => tag.toString())
 
     assert.include(result, '<link rel="modulepreload" href="/assets/main-CKiOIoD7.js"/>')
   })
 
-  test('Preload files imported from entrypoints', async ({ assert }) => {
+  test('Preload files imported from entry points', async ({ assert }) => {
     const vite = await setupViteWithManifest(config)
-    const entrypoints = await vite.generateEntryPointsTags('resources/pages/home/main.vue')
+    const entryPoints = await vite.generateEntryPointsTags('resources/pages/home/main.vue')
 
-    const result = entrypoints.map((tag) => tag.toString())
+    const result = entryPoints.map((tag) => tag.toString())
 
     assert.includeMembers(result, [
       '<link rel="modulepreload" href="/assets/app-CGO3UiiC.js"/>',
@@ -510,22 +510,22 @@ test.group('Preloading', () => {
     ])
   })
 
-  test('Preload entrypoints css files', async ({ assert }) => {
+  test('Preload entry points css files', async ({ assert }) => {
     const vite = await setupViteWithManifest(config)
-    const entrypoints = await vite.generateEntryPointsTags('resources/pages/home/main.vue')
+    const entryPoints = await vite.generateEntryPointsTags('resources/pages/home/main.vue')
 
-    const result = entrypoints.map((tag) => tag.toString())
+    const result = entryPoints.map((tag) => tag.toString())
 
     assert.includeMembers(result, [
       '<link rel="preload" as="style" href="/assets/main-BcGYH63d.css"/>',
     ])
   })
 
-  test('Preload css files of imported files of entrypoint', async ({ assert }) => {
+  test('Preload css files of imported files of entry point', async ({ assert }) => {
     const vite = await setupViteWithManifest(config)
-    const entrypoints = await vite.generateEntryPointsTags('resources/pages/home/main.vue')
+    const entryPoints = await vite.generateEntryPointsTags('resources/pages/home/main.vue')
 
-    const result = entrypoints.map((tag) => tag.toString())
+    const result = entryPoints.map((tag) => tag.toString())
 
     assert.includeMembers(result, [
       '<link rel="preload" as="style" href="/assets/main-BcGYH63d.css"/>',
@@ -538,9 +538,9 @@ test.group('Preloading', () => {
 
   test('css preload should be ordered before js preload', async ({ assert }) => {
     const vite = await setupViteWithManifest(config)
-    const entrypoints = await vite.generateEntryPointsTags('resources/pages/home/main.vue')
+    const entryPoints = await vite.generateEntryPointsTags('resources/pages/home/main.vue')
 
-    const result = entrypoints.map((tag) => tag.toString())
+    const result = entryPoints.map((tag) => tag.toString())
 
     const cssPreloadIndex = result.findIndex((tag) => tag.includes('rel="preload" as="style"'))
     const jsPreloadIndex = result.findIndex((tag) => tag.includes('rel="modulepreload"'))
@@ -550,9 +550,9 @@ test.group('Preloading', () => {
 
   test('preloads should use assetsUrl when defined', async ({ assert }) => {
     const vite = await setupViteWithManifest({ ...config, assetsUrl: 'https://cdn.url.com' })
-    const entrypoints = await vite.generateEntryPointsTags('resources/pages/home/main.vue')
+    const entryPoints = await vite.generateEntryPointsTags('resources/pages/home/main.vue')
 
-    const result = entrypoints.map((tag) => tag.toString())
+    const result = entryPoints.map((tag) => tag.toString())
 
     assert.includeMembers(result, [
       '<link rel="modulepreload" href="https://cdn.url.com/main-CKiOIoD7.js"/>',
@@ -588,7 +588,7 @@ test.group('Vite | collect css', () => {
     )
   })
 
-  test('collect recursively css files of entrypoint', async ({ assert, fs }) => {
+  test('collect recursively css files of entry point', async ({ assert, fs }) => {
     const vite = await createVite(defineConfig({}), {
       build: { rolldownOptions: { input: 'foo.ts' } },
     })
@@ -618,7 +618,7 @@ test.group('Vite | collect css', () => {
     )
   }).skip(
     true,
-    'Server-side warmupRequest only loads the direct entrypoint; nested imports are not transitively fetched the way a browser would. In a real app the browser drives the cascade and CSS is collected correctly.'
+    'Server-side warmupRequest only loads the direct entry point; nested imports are not transitively fetched the way a browser would. In a real app the browser drives the cascade and CSS is collected correctly.'
   )
 
   test('emit css link tags when ssr graph populated by a different module (issue #29)', async ({

--- a/tests/client/build.spec.ts
+++ b/tests/client/build.spec.ts
@@ -26,7 +26,7 @@ test.group('Vite 8 build | manifest', () => {
     await build({
       root: fs.basePath,
       logLevel: 'silent',
-      plugins: [adonisjs({ entrypoints: ['./resources/js/app.ts'] })],
+      plugins: [adonisjs({ entryPoints: ['./resources/js/app.ts'] })],
     })
 
     const manifest = await readManifest(fs.basePath)
@@ -44,7 +44,7 @@ test.group('Vite 8 build | manifest', () => {
     await build({
       root: fs.basePath,
       logLevel: 'silent',
-      plugins: [adonisjs({ entrypoints: ['./resources/js/app.ts'] })],
+      plugins: [adonisjs({ entryPoints: ['./resources/js/app.ts'] })],
     })
 
     const manifest = await readManifest(fs.basePath)
@@ -61,7 +61,7 @@ test.group('Vite 8 build | manifest', () => {
     await build({
       root: fs.basePath,
       logLevel: 'silent',
-      plugins: [adonisjs({ entrypoints: ['./resources/js/app.ts'] })],
+      plugins: [adonisjs({ entryPoints: ['./resources/js/app.ts'] })],
     })
 
     const manifest = await readManifest(fs.basePath)
@@ -77,7 +77,7 @@ test.group('Vite 8 build | manifest', () => {
       await build({
         root: fs.basePath,
         logLevel: 'silent',
-        plugins: [adonisjs({ entrypoints: ['./resources/js/app.ts'] })],
+        plugins: [adonisjs({ entryPoints: ['./resources/js/app.ts'] })],
       })
     } catch (error) {
       caught = error
@@ -94,7 +94,7 @@ test.group('Vite 8 build | createBuilder', () => {
     const builder = await createBuilder({
       root: fs.basePath,
       logLevel: 'silent',
-      plugins: [adonisjs({ entrypoints: ['./resources/js/app.ts'] })],
+      plugins: [adonisjs({ entryPoints: ['./resources/js/app.ts'] })],
       configFile: false,
     })
     await builder.buildApp()
@@ -114,7 +114,7 @@ test.group('Vite 8 build | plugin compat', () => {
     await build({
       root: fs.basePath,
       logLevel: 'silent',
-      plugins: [adonisjs({ entrypoints: ['./resources/js/app.ts'] })],
+      plugins: [adonisjs({ entryPoints: ['./resources/js/app.ts'] })],
     })
 
     const manifest = await readManifest(fs.basePath)
@@ -127,7 +127,7 @@ test.group('Vite 8 build | plugin compat', () => {
     await build({
       root: fs.basePath,
       logLevel: 'silent',
-      plugins: [adonisjs({ entrypoints: ['./resources/js/app.ts'] })],
+      plugins: [adonisjs({ entryPoints: ['./resources/js/app.ts'] })],
       build: { outDir: 'dist' },
     })
 

--- a/tests/client/config.spec.ts
+++ b/tests/client/config.spec.ts
@@ -18,7 +18,7 @@ test.group('Vite plugin', () => {
     await build({
       root: fs.basePath,
       logLevel: 'warn',
-      plugins: [adonisjs({ entrypoints: ['./resources/js/app.ts'] })],
+      plugins: [adonisjs({ entryPoints: ['./resources/js/app.ts'] })],
     })
 
     await assert.fileContains('public/assets/.vite/manifest.json', 'resources/js/app.ts')
@@ -30,7 +30,7 @@ test.group('Vite plugin', () => {
     await build({
       root: fs.basePath,
       logLevel: 'warn',
-      plugins: [adonisjs({ entrypoints: ['./resources/js/app.ts'] })],
+      plugins: [adonisjs({ entryPoints: ['./resources/js/app.ts'] })],
       build: { manifest: 'foo.json' },
     })
 
@@ -39,7 +39,7 @@ test.group('Vite plugin', () => {
 
   test('define the asset url', async ({ assert }) => {
     const plugin = adonisjs({
-      entrypoints: ['./resources/js/app.ts'],
+      entryPoints: ['./resources/js/app.ts'],
       assetsUrl: 'https://cdn.com',
       buildDirectory: 'my-assets',
     })[1] as Plugin
@@ -51,7 +51,7 @@ test.group('Vite plugin', () => {
 
   test('disable vite dev server cors handling', async ({ assert }) => {
     const plugin = adonisjs({
-      entrypoints: ['./resources/js/app.ts'],
+      entryPoints: ['./resources/js/app.ts'],
     })[1] as Plugin
 
     // @ts-ignore
@@ -59,9 +59,9 @@ test.group('Vite plugin', () => {
     assert.deepEqual(config.server?.cors, false)
   })
 
-  test('emit rolldownOptions.input from entrypoints', async ({ assert }) => {
+  test('emit rolldownOptions.input from entry points', async ({ assert }) => {
     const plugin = adonisjs({
-      entrypoints: ['./resources/js/app.ts', './resources/js/admin.ts'],
+      entryPoints: ['./resources/js/app.ts', './resources/js/admin.ts'],
     })[1] as Plugin
 
     // @ts-ignore
@@ -74,7 +74,7 @@ test.group('Vite plugin', () => {
 
   test('respect user-provided build.rolldownOptions.input', async ({ assert }) => {
     const plugin = adonisjs({
-      entrypoints: ['./resources/js/app.ts'],
+      entryPoints: ['./resources/js/app.ts'],
     })[1] as Plugin
 
     // @ts-ignore
@@ -87,7 +87,7 @@ test.group('Vite plugin', () => {
 
   test('respect legacy build.rollupOptions.input for backwards compat', async ({ assert }) => {
     const plugin = adonisjs({
-      entrypoints: ['./resources/js/app.ts'],
+      entryPoints: ['./resources/js/app.ts'],
     })[1] as Plugin
 
     // @ts-ignore
@@ -102,7 +102,7 @@ test.group('Vite plugin', () => {
     assert,
   }) => {
     const plugin = adonisjs({
-      entrypoints: ['./resources/js/app.ts'],
+      entryPoints: ['./resources/js/app.ts'],
     })[1] as Plugin
 
     // @ts-ignore
@@ -116,7 +116,7 @@ test.group('Vite plugin', () => {
 
   test('user manifest filename overrides default', async ({ assert }) => {
     const plugin = adonisjs({
-      entrypoints: ['./resources/js/app.ts'],
+      entryPoints: ['./resources/js/app.ts'],
     })[1] as Plugin
 
     // @ts-ignore
@@ -129,7 +129,7 @@ test.group('Vite plugin', () => {
 
   test('user outDir overrides buildDirectory', async ({ assert }) => {
     const plugin = adonisjs({
-      entrypoints: ['./resources/js/app.ts'],
+      entryPoints: ['./resources/js/app.ts'],
       buildDirectory: 'public/assets',
     })[1] as Plugin
 
@@ -140,7 +140,7 @@ test.group('Vite plugin', () => {
 
   test('preserve user cors config when defined', async ({ assert }) => {
     const plugin = adonisjs({
-      entrypoints: ['./resources/js/app.ts'],
+      entryPoints: ['./resources/js/app.ts'],
     })[1] as Plugin
 
     // @ts-ignore

--- a/tests/client/resolve_assets.spec.ts
+++ b/tests/client/resolve_assets.spec.ts
@@ -59,7 +59,7 @@ test.group('resolveAssets | chunks (glob)', () => {
       logLevel: 'silent',
       plugins: [
         adonisjs({
-          entrypoints: ['./resources/js/app.ts'],
+          entryPoints: ['./resources/js/app.ts'],
           assets: { chunks: ['./resources/images/**/*.svg'] },
         }),
       ],
@@ -81,7 +81,7 @@ test.group('resolveAssets | assets (raw)', () => {
       logLevel: 'silent',
       plugins: [
         adonisjs({
-          entrypoints: ['./resources/js/app.ts'],
+          entryPoints: ['./resources/js/app.ts'],
           assets: { assets: ['./resources/images/logo.svg'] },
         }),
       ],
@@ -104,7 +104,7 @@ test.group('resolveAssets | assets (raw)', () => {
       logLevel: 'silent',
       plugins: [
         adonisjs({
-          entrypoints: ['./resources/js/app.ts'],
+          entryPoints: ['./resources/js/app.ts'],
           assets: { assets: ['./resources/images/logo.svg'] },
         }),
       ],
@@ -124,7 +124,7 @@ test.group('resolveAssets | assets (raw)', () => {
       logLevel: 'silent',
       plugins: [
         adonisjs({
-          entrypoints: ['./resources/js/app.ts'],
+          entryPoints: ['./resources/js/app.ts'],
           assets: { assets: ['./resources/images/logo.svg'] },
         }),
       ],
@@ -145,7 +145,7 @@ test.group('resolveAssets | assets (raw)', () => {
       logLevel: 'silent',
       plugins: [
         adonisjs({
-          entrypoints: ['./resources/js/app.ts'],
+          entryPoints: ['./resources/js/app.ts'],
           assets: { assets: ['./resources/images/logo.svg'] },
         }),
       ],
@@ -166,7 +166,7 @@ test.group('resolveAssets | assets (raw)', () => {
       logLevel: 'silent',
       plugins: [
         adonisjs({
-          entrypoints: ['./resources/js/app.ts'],
+          entryPoints: ['./resources/js/app.ts'],
           assets: { assets: ['./resources/images/logo.svg'] },
         }),
       ],
@@ -184,7 +184,7 @@ test.group('resolveAssets | assets (raw)', () => {
       logLevel: 'silent',
       plugins: [
         adonisjs({
-          entrypoints: ['./resources/js/app.ts'],
+          entryPoints: ['./resources/js/app.ts'],
           assets: {
             chunks: ['./resources/svg/**/*.svg'],
             assets: ['./resources/images/logo.svg'],


### PR DESCRIPTION
<!---
Please carefully read the contribution docs before creating a pull request
 👉 https://github.com/adonisjs/.github/blob/main/docs/CONTRIBUTING.md
-->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [X] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [X] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

This PR simply corrects an inconsistency regarding JavaScript conventions and the codebase. Since “entry points” is two words, it should use camelCase.

**_⚠️Breakings Changes_** :
* `entrypoints` option is renamed `entryPoints`
* `serverEntrypoints` option is renamed `serverEntryPoints`

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
